### PR TITLE
Add topic submission form with validation and default date

### DIFF
--- a/common.test.mjs
+++ b/common.test.mjs
@@ -1,4 +1,4 @@
-import { getUserIDs } from "./common.mjs";
+import { getUserIds } from "./common.mjs";
 import assert from "node:assert";
 import test from "node:test";
 

--- a/index.html
+++ b/index.html
@@ -16,6 +16,18 @@
         <!-- Options will be added dynamically -->
       </select>
 
+      <!-- Add Topic Form -->
+      <h2>Add New Topic</h2>
+      <form id="add-topic">
+        <label for="topic-name">Topic Name:</label>
+        <input type="text" id="topic-name" name="topic-name" placeholder="Enter a new topic" required />
+
+        <label for="start-date">Select a Start Date:</label>
+        <input type="date" id="start-date" name="start-date" required />
+
+        <button type="submit" id="submit-btn">Add a Topic</button>
+      </form>
+
     </main>
 
     <!-- JavaScript -->

--- a/script.mjs
+++ b/script.mjs
@@ -28,4 +28,33 @@ function populateUserDropdown() {
 
 populateUserDropdown();
 
+const addTopicForm = document.getElementById("add-topic");
+const topicNameInput = document.getElementById("topic-name");
+const dateInput = document.getElementById("start-date");
+
+// Sets the date input's value to today's date
+function setDefaultDate() {
+   dateInput.valueAsDate = new Date();
+}
+
+function handleTopicSubmit(event) {
+ event.preventDefault();
+
+ const topicName = topicNameInput.value.trim(); // .trim() removes whitespace from the topic name
+ const startDate = dateInput.value;
+
+ if (!topicName || !startDate) {
+   alert("Please enter both topic name and start date.");
+   return;
+ }
+
+ addTopicForm.reset();
+ setDefaultDate();
+}
+
+setDefaultDate();
+
+// This ensures the function runs when the user either clicks the submit button or presses the Enter key.
+addTopicForm.addEventListener("submit", handleTopicSubmit);
+
 export { populateUserDropdown };


### PR DESCRIPTION
Hi @sarawone,

This PR completes the implementation.

### Features:
- Added an HTML form with:
  - Topic name input (text)
  - Date picker (defaults to today's date)
  - Submit button
- Inputs are validated to ensure both fields are filled before submission
- Form can be submitted using either the Enter key or the submit button
- The form resets after submission, and the date field returns to today's date

